### PR TITLE
Feat/local rag chatbot

### DIFF
--- a/RAG_CHATBOT_DOCS.md
+++ b/RAG_CHATBOT_DOCS.md
@@ -1,516 +1,498 @@
-# RAG Chatbot Feature — Implementation Documentation
+# RAG-Based Chatbot — Technical Documentation
+
+**Module:** 4-SEI-10-899 | Software Engineering and Internship  
+**Team Project:** StudyHub  
+**Spring 2025-2026 | Central Asian University**
+
+---
 
 ## Overview
 
-StudyHub now includes an AI-powered chatbot assistant that uses **Retrieval-Augmented Generation (RAG)** to answer questions grounded in uploaded study documents. Unlike a plain LLM that can only hallucinate generic answers, the RAG chatbot retrieves the most relevant passages from a vector database built from real documents before generating a response — making answers accurate, citable, and traceable to a source.
+For this assessment we integrated a RAG-based chatbot into our existing StudyHub application. The chatbot acts as a help-desk assistant that can only answer questions about StudyHub — its features, APIs, authentication, and architecture. It is built on top of fully local models running through Ollama, so no data is sent to any external API at chat time.
 
-### What users can do
-- Ask questions about how to use StudyHub (modules, resources, flashcards, etc.)
-- Ask questions about study material that has been indexed (lecture notes, PDFs, slides)
-- See which document and page number each answer came from
-- The chatbot widget is available on every page — no navigation required
+The main things the chatbot can do:
+- Answer questions about StudyHub using retrieved context from our documentation
+- Reject any question that is not about StudyHub with a consistent message
+- Remember the last few turns of a conversation so follow-up questions work
+- Show the user which document the answer came from (source attribution)
 
 ---
 
-## What is RAG?
+## What is RAG and Why We Used It
 
-**Retrieval-Augmented Generation** is a pattern that combines a vector database (for finding relevant facts) with a large language model (for generating a natural-language response).
+RAG (Retrieval-Augmented Generation) solves a core problem with LLMs: they hallucinate. If you just ask a plain LLM about StudyHub it will make things up, because it has never seen our documentation.
+
+With RAG, instead of relying on the model's internal memory, we first search our own documentation for relevant chunks, then pass those chunks to the model as context. The model can only answer from what we give it.
 
 ```
 Without RAG:
-  User question  ──►  LLM  ──►  Answer
-                       (may hallucinate)
+  User question ──► LLM ──► Made-up answer
 
 With RAG:
-  User question  ──►  Embedding model  ──►  Vector search  ──►  Top-K chunks
-                                                                      │
-                       LLM  ◄── Context (chunks) + Question ──────────┘
-                        │
-                        ▼
-                    Grounded answer + Sources
+  User question ──► embed ──► search ChromaDB ──► top-4 relevant chunks
+                                                          │
+                          LLM ◄── system prompt + chunks ─┘
+                           │
+                           ▼
+                    Grounded answer + source attribution
 ```
 
-The key advantage is **grounding**: the LLM is explicitly given the relevant text from real documents, so it cannot invent facts.
+If no relevant chunk is found above the similarity threshold, we reject the question before the LLM is even called. This makes rejection fast and consistent.
 
 ---
 
-## System Architecture
+## Architecture
 
 ### Service Map
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                        Docker Network                    │
-│                                                         │
-│  ┌──────────┐   /api/v1/*   ┌──────────┐               │
-│  │ Frontend │──────────────►│ Go       │               │
-│  │ (React)  │               │ Backend  │               │
-│  │  :80     │◄──────────────│  :8080   │               │
-│  └──────────┘               └────┬─────┘               │
-│                                  │                      │
-│                    POST /chat     │                      │
-│                                  ▼                      │
-│                          ┌──────────────┐               │
-│                          │  RAG Service │               │
-│                          │  (Python)    │               │
-│                          │   :8001      │               │
-│                          └──────┬───────┘               │
-│                                 │                       │
-│                    ┌────────────┴────────────┐          │
-│                    ▼                         ▼          │
-│             ┌────────────┐          ┌──────────────┐    │
-│             │  ChromaDB  │          │  Gemini API  │    │
-│             │ (local FS) │          │  (external)  │    │
-│             └────────────┘          └──────────────┘    │
-│                                                         │
-│  ┌──────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐   │
-│  │  db  │  │ rabbitmq │  │   s3     │  │gotenberg │   │
-│  └──────┘  └──────────┘  └──────────┘  └──────────┘   │
-└─────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│                        Docker Network                         │
+│                                                              │
+│  ┌──────────┐   /api/v1/*    ┌────────────┐                  │
+│  │ Frontend │───────────────►│ Go Backend │                  │
+│  │  React   │◄───────────────│   :8080    │                  │
+│  │  :80     │                └─────┬──────┘                  │
+│  └──────────┘                      │ POST /chat              │
+│                                    ▼                         │
+│                          ┌──────────────────┐                │
+│                          │   RAG Service    │                │
+│                          │  Python/FastAPI  │                │
+│                          │     :8001        │                │
+│                          └────────┬─────────┘               │
+│                                   │                          │
+│                    ┌──────────────┴──────────────┐           │
+│                    ▼                             ▼           │
+│             ┌────────────┐             ┌──────────────┐      │
+│             │  ChromaDB  │             │    Ollama    │      │
+│             │  (disk)    │             │  (host)      │      │
+│             └────────────┘             └──────────────┘      │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
 ```
 
-### Fallback Strategy
+The RAG service is a separate Python microservice. We kept it separate from the Go backend because the LangChain ecosystem is Python-native, and trying to do RAG in Go would have been significantly more complex. The Go backend proxies chat requests to it and falls back to a direct Gemini call if the RAG service is unavailable.
 
-The Go backend always has a safety net. If the RAG service is down (e.g., during startup or a crash), it automatically falls back to a direct Gemini call with the static StudyHub system prompt.
+### Models
 
-```
-Go ChatHandler
-     │
-     ├─► RAG service available?
-     │       YES ──► call /chat ──► return answer + sources
-     │       NO  ──► log warning
-     │                   │
-     └───────────────────► Gemini direct call ──► return answer
-```
+We used two local Ollama models as recommended in the assessment spec:
 
----
+| Role | Model | Size | Purpose |
+|------|-------|------|---------|
+| Embeddings | `nomic-embed-text-v2-moe` | 957 MB | Converts text to vectors for similarity search |
+| LLM | `gemma4:e4b` | ~3 GB | Reads retrieved chunks and generates the answer |
 
-## Request / Response Flow
+Both models run on the host machine through Ollama. The Docker containers connect to them via `host.docker.internal:11434`.
 
-### Step-by-step: User asks a question
+### Fallback
+
+If the RAG service or Ollama is down, the Go backend falls back to a direct Gemini API call so the chat widget does not break completely. The fallback does not have source attribution.
 
 ```
-1. User types message in ChatWidget (React)
+ChatHandler receives request
         │
-        ▼
-2. POST /api/v1/chat  { "message": "What is a module run?" }
-        │  (JWT token in Authorization header)
-        ▼
-3. Go ChatHandler — validates request, checks ragServiceURL
-        │
-        ▼
-4. POST http://rag-service:8001/chat  { "message": "..." }
-        │
-        ▼
-5. RAG Service — embeds the question with Gemini text-embedding-004
-        │
-        ▼
-6. ChromaDB vector search — finds top-4 most similar document chunks
-        │
-        ▼
-7. Build prompt:
-        [System prompt]
-        [Retrieved chunks as context]
-        [User question]
-        │
-        ▼
-8. Gemini 2.5 Flash Lite generates answer
-        │
-        ▼
-9. Return { "reply": "...", "sources": [{ "source": "lecture1.pdf", "page": 3 }] }
-        │
-        ▼
-10. Go wraps in { "data": { "reply": "...", "sources": [...] } } → 200 OK
-        │
-        ▼
-11. Frontend Axios interceptor unwraps { "data": ... }
-        │
-        ▼
-12. ChatWidget renders answer (Markdown) + source badges
+        ├─► RAG service available?
+        │       YES ──► returns grounded answer + sources
+        │       NO  ──► logs warning
+        │                    │
+        └────────────────────► Gemini direct call ──► answer (no sources)
 ```
 
 ---
 
-## Component Breakdown
+## Build Time vs. Runtime Separation
 
-### 1. Python RAG Service (`rag-service/`)
+This was one of the most important design decisions we made. Document ingestion (loading files, chunking, embedding) is expensive — it calls the embedding model for every chunk. Doing this on every startup or on every user question would be completely impractical.
 
-The self-contained microservice responsible for all RAG logic.
+Our solution: run ingestion exactly once at build time, persist the results to disk, and just load from disk on every subsequent start.
+
+```
+BUILD TIME (runs once)                  RUNTIME (runs on every question)
+──────────────────────                  ────────────────────────────────
+data/studyhub_docs.md                   User question
+         │                                      │
+         ▼                                      ▼
+  DirectoryLoader                       OllamaEmbeddings
+  (PDF, TXT, MD)                        (nomic-embed-text-v2-moe)
+         │                                      │
+         ▼                                      ▼
+  RecursiveCharacterTextSplitter        ChromaDB similarity search
+  chunk_size=800, overlap=150           top-4 chunks + cosine scores
+         │                                      │
+         ▼                               relevance check (≥ 0.30)
+  OllamaEmbeddings                             │
+  (nomic-embed-text-v2-moe)             ┌──────┴──────┐
+         │                            PASS           FAIL
+         ▼                              │               │
+  ChromaDB                        build prompt    "I can only answer
+  (persisted to chroma_db/)             │         questions about StudyHub"
+                                        ▼
+                                 ChatOllama (gemma4:e4b, temp=0.2)
+                                        │
+                                        ▼
+                                 answer + sources
+```
+
+The build step is handled by `build_index.py`. When the Docker container starts, it checks if `chroma_db/` already has data. If yes, it exits immediately and the server starts in under a second. If not (first start), it builds the index. This means `docker compose up` is always fast after the first run.
+
+```python
+# build_index.py — skip if index already exists
+if not force and os.path.exists(DB_DIR) and any(os.scandir(DB_DIR)):
+    print("Vector index already exists — skipping build.")
+    sys.exit(0)
+
+# First run: build the full index
+bot = RAGChatbot()
+result = bot.rebuild()
+# Output: "Indexed 1 document(s) into 25 chunks."
+```
+
+We also expose `POST /rebuild` as an endpoint so we can re-index without restarting the container after adding new documents.
+
+---
+
+## Implementation Details
+
+### File Structure
 
 ```
 rag-service/
-├── main.py          FastAPI application, lifespan startup, REST endpoints
-├── rag.py           RAGChatbot class — document loading, indexing, retrieval, generation
-├── requirements.txt Python dependencies
-├── Dockerfile       Python 3.12-slim image
-└── data/            Drop PDFs and .txt files here to index them
+├── main.py           FastAPI app — endpoints, request/response models
+├── rag.py            RAGChatbot class — all RAG logic
+├── build_index.py    Build-time script — indexes data/ into ChromaDB
+├── requirements.txt  Python dependencies
+├── Dockerfile        Python 3.12-slim, runs build_index.py then uvicorn
+└── data/
+    └── studyhub_docs.md   Knowledge base (~600 lines of StudyHub documentation)
 ```
 
-#### `rag.py` — RAGChatbot class
+### Initialisation (`rag.py`)
 
-| Method | Responsibility |
-|---|---|
-| `__init__` | Creates Gemini embeddings client and Gemini LLM client |
-| `_init_db` | Loads existing ChromaDB if present, otherwise calls `rebuild()` |
-| `_load_documents` | Uses LangChain `DirectoryLoader` to load all PDFs and .txt files from `data/` |
-| `rebuild` | Splits documents into 800-char chunks with 150-char overlap, embeds them, saves to ChromaDB |
-| `chat` | Embeds question, retrieves top-4 chunks, builds prompt, calls Gemini, returns answer + sources |
+```python
+from langchain_ollama import ChatOllama, OllamaEmbeddings
 
-#### `main.py` — FastAPI endpoints
+class RAGChatbot:
+    def __init__(self):
+        self.embeddings = OllamaEmbeddings(
+            model="nomic-embed-text-v2-moe",
+            base_url="http://localhost:11434",
+        )
+        self.llm = ChatOllama(
+            model="gemma4:e4b",
+            base_url="http://localhost:11434",
+            temperature=0.2,  # low temperature = factual, not creative
+        )
+        self.vector_db = None
+        self._init_db()  # load existing index, or build fresh if it doesn't exist
+```
 
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/health` | Liveness check — returns `{"status": "ok"}` |
-| `POST` | `/chat` | Body: `{"message": "..."}` — returns `{"reply": "...", "sources": [...]}` |
-| `POST` | `/rebuild` | Re-scans `data/` and rebuilds the vector index — use after adding new documents |
+### Chunking and Indexing
 
-#### Chunking strategy
+```python
+def rebuild(self):
+    docs = self._load_documents()  # reads all .pdf, .txt, .md files from data/
 
-Documents are split using `RecursiveCharacterTextSplitter` with:
-- **chunk_size = 800** characters — small enough to stay focused, large enough for context
-- **chunk_overlap = 150** characters — overlap prevents answers from being cut at boundaries
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=800,    # roughly one paragraph per chunk
+        chunk_overlap=150  # 150-char overlap so sentences on chunk boundaries aren't lost
+    )
+    chunks = splitter.split_documents(docs)
 
-#### Embeddings and model
+    self.vector_db = Chroma.from_documents(
+        documents=chunks,
+        embedding=self.embeddings,
+        persist_directory="chroma_db",  # saved to disk — only runs once
+    )
+```
 
-| Component | Model | Why |
-|---|---|---|
-| Embeddings | `models/text-embedding-004` (Google) | Same API key as existing Gemini usage, high quality |
-| LLM | `gemini-2.5-flash-lite` (Google) | Fast, cheap, already used in the project |
-| Vector DB | ChromaDB (local filesystem) | Zero infrastructure cost, persists between restarts |
+We chose `chunk_size=800` with `chunk_overlap=150` because it keeps each chunk focused on a single topic while ensuring that content spanning a boundary is not lost. The 800-character limit is roughly one paragraph, which is a natural unit of meaning for a help document.
+
+### Retrieval and Rejection (FR-01, FR-03)
+
+```python
+# Retrieve top-4 chunks with cosine similarity scores
+results = self.vector_db.similarity_search_with_relevance_scores(
+    retrieval_query, k=4
+)
+
+# Filter by relevance threshold
+relevant = [(doc, score) for doc, score in results if score >= 0.30]
+
+if not relevant and results:
+    # All chunks scored below threshold — question is off-topic
+    return "I can only answer questions about StudyHub.", []
+```
+
+The threshold of **0.30** acts as a hard gate. If no chunk from our documentation scores at least 0.30 cosine similarity with the question, the system rejects it immediately without calling the LLM at all. This is efficient (no token cost) and consistent (the rejection message is always the same).
+
+### Multi-Turn Context (FR-06)
+
+One issue we ran into: for short follow-up questions like "where is it stored?", the question alone is too vague for vector search to find anything relevant. The embedding of that phrase doesn't match anything specific in the documentation.
+
+Our solution was to enrich the retrieval query by prepending the previous user message. The LLM still receives only the current question, but the retrieval benefits from the added context.
+
+```python
+def chat(self, question: str, history: list = None):
+    # Enrich retrieval query with previous user message for follow-up questions
+    retrieval_query = question
+    if history:
+        last_user = next(
+            (m["content"] for m in reversed(history) if m.get("role") == "user"),
+            None
+        )
+        if last_user:
+            retrieval_query = f"{last_user} {question}"
+
+    # ... retrieval ...
+
+    # Build message list with conversation history for multi-turn context
+    messages = [SystemMessage(content=system_with_context)]
+    for msg in (history or [])[-6:]:  # last 6 messages = 3 full exchanges
+        if msg["role"] == "user":
+            messages.append(HumanMessage(content=msg["content"]))
+        elif msg["role"] == "assistant":
+            messages.append(AIMessage(content=msg["content"]))
+
+    messages.append(HumanMessage(content=question))
+    response = self.llm.invoke(messages)
+```
 
 ---
 
-### 2. Go Backend Changes (`backend/`)
+## Prompt Engineering Strategy
 
-Three files were modified to wire the RAG service into the existing request pipeline.
+The system prompt is injected at the top of every LLM request. We designed it with two goals: tell the model its role, and give it explicit rules for rejection.
 
-#### `internal/config/config.go`
+```python
+_SYSTEM = """You are StudyHub Assistant, the official help-desk chatbot for the StudyHub application.
 
-Added one field:
+StudyHub is an academic study management platform. Students use it to organise modules, share study
+resources (files and links), generate AI-powered flashcards, and collaborate via comments.
+
+YOUR STRICT RULES:
+1. Only answer questions about StudyHub — its features, APIs, authentication, architecture, and usage.
+2. Base every answer on the CONTEXT PROVIDED below. Do not invent facts.
+3. If the provided context does not contain enough information to answer confidently, respond with exactly:
+   "I can only answer questions about StudyHub."
+4. If the question is clearly unrelated to StudyHub (e.g. history, maths, other software, personal advice),
+   respond with exactly: "I can only answer questions about StudyHub."
+5. Be concise. Use bullet points or numbered lists where helpful.
+"""
+```
+
+A few decisions we made here:
+
+**Why give the exact rejection phrase in the prompt?** We want the rejection to be consistent and predictable. If we just say "reject unrelated questions politely", different phrasings would appear. By specifying the exact string, the UI can also detect it reliably if needed.
+
+**Why temperature=0.2?** A higher temperature makes the model more creative and varied — good for creative writing, bad for a help desk. We want factual, reproducible answers. Low temperature keeps the model close to what the retrieved context says.
+
+**Two-layer rejection:** We deliberately have rejection at two levels:
+1. **Score gate** (before LLM): if no chunk scores ≥ 0.30, return rejection immediately
+2. **Prompt instruction** (inside LLM): even if chunks are retrieved, tell the model to reject if context is insufficient
+
+This means even a borderline retrieval that sneaks past the score gate still gets rejected if the LLM judges the context insufficient.
+
+---
+
+## Knowledge Base
+
+The chatbot's knowledge comes entirely from `rag-service/data/studyhub_docs.md` — a document we wrote covering everything about StudyHub. We chose Markdown over PDF because it is easier to maintain and update.
+
+| Section | What it covers |
+|---------|----------------|
+| System overview | What StudyHub is, who it's for, the core value proposition |
+| Core features | Modules, weeks, resources (files/links), flashcards, decks, comments, academic terms |
+| Authentication | JWT login flow, where the token is stored, how to send it in requests |
+| API endpoints | All 29 endpoints — method, path, auth requirement, request/response examples |
+| How-to guides | Step-by-step instructions for every main workflow |
+| Architecture | Tech stack, deployment diagram, how the services connect |
+| User roles | Admin vs. regular user permissions |
+| Common Q&A | Pre-written answers to the most likely questions |
+
+This document is baked into the Docker image at build time. On first container start it gets chunked, embedded, and stored in ChromaDB. The index then persists across restarts via a named Docker volume.
+
+---
+
+## Integration into the Application
+
+### Backend (Go)
+
+The existing Go backend has a `ChatHandler` that forwards requests to the RAG service. We added conversation history support — the handler accepts a `history` array and passes it through:
+
 ```go
-RAGServiceURL string `env:"RAG_SERVICE_URL" envDefault:"http://rag-service:8001"`
-```
-
-The default points at the Docker service name. For local development without Docker, set `RAG_SERVICE_URL=http://localhost:8001`.
-
-#### `internal/http/http.go`
-
-Added `ragServiceURL string` to `HTTPServer` struct and to `NewHTTPServer(...)` constructor. No routing changes — the `/chat` route was already registered.
-
-#### `internal/http/chat_handler.go`
-
-`ChatHandler` now:
-1. Calls `callRAGService(srv.ragServiceURL, req.Message)` — a private function that POSTs to the Python service
-2. On success: returns `chatResponse{Reply, Sources}` to the frontend
-3. On any error (service down, timeout, bad status): logs a warning and falls back to `srv.geminiClient.Chat()`
-
-The HTTP client used by `callRAGService` has a 30-second timeout, matching a reasonable LLM response time.
-
-**Updated response struct:**
-```go
-type chatResponse struct {
-    Reply   string       `json:"reply"`
-    Sources []chatSource `json:"sources,omitempty"`  // new field
+type chatRequest struct {
+    Message string               `json:"message"`
+    History []chatHistoryMessage `json:"history"`
 }
 
-type chatSource struct {
-    Source string `json:"source"`   // filename, e.g. "lecture3.pdf"
-    Page   *int   `json:"page,omitempty"` // 0-indexed page number
+func (srv *HTTPServer) ChatHandler(w http.ResponseWriter, r *http.Request) {
+    var req chatRequest
+    json.NewDecoder(r.Body).Decode(&req)
+
+    if srv.ragServiceURL != "" {
+        if reply, sources, err := callRAGService(srv.ragServiceURL, req.Message, req.History); err == nil {
+            ResponseWithJSON(w, http.StatusOK, chatResponse{Reply: reply, Sources: sources})
+            return
+        }
+        slog.Warn("rag service unavailable, falling back to gemini")
+    }
+
+    reply, _ := srv.geminiClient.Chat(r.Context(), req.Message)
+    ResponseWithJSON(w, http.StatusOK, chatResponse{Reply: reply})
 }
 ```
 
----
+The HTTP client timeout is set to 60 seconds because local Ollama inference on first call can be slow while the model loads into memory.
 
-### 3. Frontend Changes (`frontend/`)
+### Frontend (React)
 
-#### `src/api/chat.ts`
+The chat widget sends the full conversation history with every message. Source attribution is displayed as small file badges below each bot reply.
 
-The API function now returns a structured object instead of a plain string:
 ```typescript
-export interface ChatSource {
-  source: string
-  page?: number
-}
+const send = async () => {
+    const text = input.trim()
+    setMessages(prev => [...prev, { role: 'user', content: text }])
 
-export interface ChatReply {
-  reply: string
-  sources: ChatSource[]
-}
-```
+    const history = messages.map(m => ({ role: m.role, content: m.content }))
+    const { reply, sources } = await chatApi.sendMessage(text, history)
 
-#### `src/components/layout/ChatWidget.tsx`
-
-Each assistant message now stores its sources alongside the content:
-```typescript
-interface Message {
-  role: 'user' | 'assistant'
-  content: string
-  sources?: ChatSource[]   // new
+    setMessages(prev => [...prev, { role: 'assistant', content: reply, sources }])
 }
 ```
 
-Source badges are rendered below each RAG-grounded reply:
-
-```
-┌──────────────────────────────────────────────┐
-│  A module run is a specific instance of a    │
-│  module delivered in a given semester...      │
-│                                              │
-│  [📄 week1-notes.pdf p.4] [📄 syllabus.pdf] │
-└──────────────────────────────────────────────┘
+```tsx
+{msg.sources && msg.sources.length > 0 && (
+    <div className="flex flex-wrap gap-1 px-1">
+        {msg.sources.map((s, j) => (
+            <span key={j} className="inline-flex items-center gap-1 text-[10px]
+                                     text-gray-500 bg-gray-100 rounded px-1.5 py-0.5">
+                <FileText className="h-2.5 w-2.5" />
+                {s.source}{s.page != null ? ` p.${s.page + 1}` : ''}
+            </span>
+        ))}
+    </div>
+)}
 ```
 
 ---
 
-## Data Flow Diagrams
+## Deployment
 
-### Document Indexing (one-time or on /rebuild)
-
-```
-data/ folder
-    │
-    ├── lecture1.pdf  ──┐
-    ├── lecture2.pdf  ──┤  DirectoryLoader (LangChain)
-    ├── notes.txt     ──┘
-              │
-              ▼
-    RecursiveCharacterTextSplitter
-    chunk_size=800, overlap=150
-              │
-              ▼
-    [ chunk_1 ][ chunk_2 ][ chunk_3 ] ... [ chunk_N ]
-              │
-              ▼
-    GoogleGenerativeAIEmbeddings
-    (text-embedding-004)
-              │
-              ▼
-    768-dimensional float vectors
-              │
-              ▼
-    ChromaDB  (persisted to ./chroma_db/)
-```
-
-### Query / Answer Flow
-
-```
-User question: "What is a module run?"
-              │
-              ▼
-    GoogleGenerativeAIEmbeddings (same model)
-              │
-              ▼
-    768-dim query vector
-              │
-              ▼
-    ChromaDB cosine similarity search  →  top-4 chunks
-              │
-              ▼
-    Prompt assembly:
-    ┌─────────────────────────────────────────┐
-    │ [System: StudyHub assistant context]    │
-    │ [Context chunk 1]                       │
-    │ [Context chunk 2]                       │
-    │ [Context chunk 3]                       │
-    │ [Context chunk 4]                       │
-    │ User: What is a module run?             │
-    │ Assistant:                              │
-    └─────────────────────────────────────────┘
-              │
-              ▼
-    Gemini 2.5 Flash Lite
-              │
-              ▼
-    "A module run is a specific instance of a
-     module delivered in a given semester..."
-              │
-              ▼
-    Sources: [{ source: "syllabus.pdf", page: 2 }]
-```
-
----
-
-## API Reference
-
-### RAG Service (internal, port 8001)
-
-#### `GET /health`
-```
-Response 200:
-{ "status": "ok" }
-```
-
-#### `POST /chat`
-```
-Request:
-{ "message": "string" }
-
-Response 200:
-{
-  "reply": "string",
-  "sources": [
-    { "source": "filename.pdf", "page": 3 }
-  ]
-}
-
-Response 400:
-{ "detail": "message is required" }
-```
-
-#### `POST /rebuild`
-```
-Response 200 (documents found):
-{
-  "status": "ok",
-  "documents": 5,
-  "chunks": 142,
-  "message": "Indexed 5 document(s) into 142 chunks."
-}
-
-Response 200 (no documents):
-{
-  "status": "empty",
-  "chunks": 0,
-  "message": "No documents found. Drop PDFs or .txt files into data/ and call /rebuild."
-}
-```
-
-### Go Backend (public, port 8080)
-
-#### `POST /api/v1/chat`
-
-Requires `Authorization: Bearer <jwt_token>`.
-
-```
-Request:
-{ "message": "string" }
-
-Response 200:
-{
-  "data": {
-    "reply": "string",
-    "sources": [
-      { "source": "lecture1.pdf", "page": 2 }
-    ]
-  }
-}
-
-Response 400:
-{ "error": { "code": 400, "message": "message is required" } }
-
-Response 500:
-{ "error": { "code": 500, "message": "failed to get response from AI" } }
-```
-
----
-
-## Setup and Configuration
-
-### Environment Variables
-
-| Variable | Default | Description |
-|---|---|---|
-| `GEMINI_API_KEY` | *(required)* | Google Gemini API key — used by both the RAG service and the Go backend |
-| `RAG_SERVICE_URL` | `http://rag-service:8001` | URL the Go backend uses to reach the RAG service |
-| `DATA_DIR` | `data` | Directory the RAG service scans for documents |
-| `DB_DIR` | `chroma_db` | Directory where ChromaDB persists its vector index |
-
-### Adding Documents to the Knowledge Base
-
-1. Place `.pdf` or `.txt` files into `rag-service/data/`
-2. Trigger a re-index:
+### Prerequisites
 
 ```bash
-# In development (port is exposed):
-curl -X POST http://localhost:8001/rebuild
-
-# Via docker exec:
-docker compose exec rag-service curl -X POST http://localhost:8001/rebuild
+# Install Ollama then pull the two models (one-time setup)
+ollama pull nomic-embed-text-v2-moe   # 957 MB
+ollama pull gemma4:e4b                 # ~3 GB
 ```
 
-3. The vector database is rebuilt in-place — no restart needed.
-
-### Running with Docker Compose
-
-**Development** (source code mounted, RAG service port exposed):
-```bash
-docker compose -f docker-compose.dev.yml up --build
-```
-RAG service admin endpoints are accessible at `http://localhost:8001`.
-
-**Production:**
-```bash
-docker compose up --build
-```
-RAG service is internal-only (no published port).
-
-### Running the RAG Service Locally (without Docker)
+### Running locally (no Docker)
 
 ```bash
 cd rag-service
 pip install -r requirements.txt
-export GEMINI_API_KEY=your-key-here
-uvicorn main:app --host 0.0.0.0 --port 8001 --reload
+
+# Build the vector index (runs once, skips on subsequent runs)
+python3 build_index.py
+
+# Start the service
+OLLAMA_BASE_URL=http://localhost:11434 uvicorn main:app --port 8001 --reload
 ```
 
-Then set `RAG_SERVICE_URL=http://localhost:8001` for the Go backend.
+Set `RAG_SERVICE_URL=http://localhost:8001` in the Go backend env.
+
+### Running with Docker Compose
+
+```bash
+# Development (RAG port exposed)
+docker compose -f docker-compose.dev.yml up --build
+
+# Production
+docker compose up --build
+```
+
+The `OLLAMA_BASE_URL` in both compose files is set to `http://host.docker.internal:11434` so the container can reach the Ollama instance running on the host machine.
+
+### Dockerfile
+
+```dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py rag.py build_index.py ./
+COPY data/ ./data/
+
+RUN mkdir -p chroma_db
+EXPOSE 8001
+
+# On first start: build index then serve.
+# On subsequent starts: index already exists, skip straight to uvicorn.
+CMD ["sh", "-c", "python3 build_index.py && uvicorn main:app --host 0.0.0.0 --port 8001"]
+```
+
+### Rebuilding the index after adding documents
+
+```bash
+# Drop new files into rag-service/data/ then call the rebuild endpoint
+curl -X POST http://localhost:8001/rebuild
+
+# Or force rebuild from inside the container
+docker compose exec rag-service python3 build_index.py --force
+```
 
 ---
 
-## Technology Choices
+## Test Evidence
 
-| Choice | Alternative considered | Reason |
-|---|---|---|
-| **Gemini embeddings** | Ollama (local) | No extra installation needed; same API key already in the project |
-| **ChromaDB** | Pinecone, Weaviate | Zero cost, runs locally, persists to disk, no extra service |
-| **FastAPI** | Flask, Django | Async-ready, automatic OpenAPI docs, Pydantic validation |
-| **Python microservice** | Embedding RAG into Go | LangChain ecosystem is Python-native; avoids porting complex logic |
-| **Gemini 2.5 Flash Lite** | GPT-4, Claude | Already in use, lowest cost, fast response time |
-| **Fallback to direct Gemini** | Return error if RAG is down | Guarantees chatbot always works even if RAG service crashes |
+### System Q&A (10 cases)
+
+| # | Question | Bot Reply (summarised) | Source |
+|---|----------|------------------------|--------|
+| 1 | What is StudyHub? | StudyHub is an academic study management platform where students organise modules, share resources, and generate flashcards. | studyhub_docs.md |
+| 2 | How do I log in? | Send a POST request to `/api/v1/auth/login` with your email and password. The response includes a JWT token to use in the Authorization header. | studyhub_docs.md |
+| 3 | Where is the auth token stored? | The JWT token is stored in `localStorage` under the key `auth_token`. It is automatically attached to every API request by the Axios interceptor. | studyhub_docs.md |
+| 4 | How do I upload a file? | Navigate to a Week Detail page, click Upload File, select your file, and confirm. The file is sent as multipart/form-data to `POST /api/v1/resources/file/{week_id}`. | studyhub_docs.md |
+| 5 | What is a module run? | A module run is a specific instance of a module in a given semester and year. One module can have multiple runs — for example, the same course in Spring 2025 and Fall 2025. | studyhub_docs.md |
+| 6 | Can I add a link as a resource? | Yes. On a Week Detail page click Add Link, provide a name and URL, and submit. This calls `POST /api/v1/resources/link/{week_id}`. | studyhub_docs.md |
+| 7 | What API endpoint lists all modules? | `GET /api/v1/modules` returns a list of all available modules. No auth is required. | studyhub_docs.md |
+| 8 | How does the flashcard feature work? | You can generate AI-powered flashcards from your study materials. Flashcards are grouped into decks and can be reviewed in the application. | studyhub_docs.md |
+| 9 | What is the tech stack? | The backend is Go with the Chi router and PostgreSQL. The frontend is React + TypeScript with Tailwind CSS. Files are stored on AWS S3. The chatbot runs on Python/FastAPI with Ollama. | studyhub_docs.md |
+| 10 | What is the difference between admin and regular users? | Admin users can manage modules, academic terms, and all system content. Regular users can upload resources to weeks they have access to and manage their own content. | studyhub_docs.md |
+
+### Rejection Cases (5 cases)
+
+| # | Question | Bot Reply |
+|---|----------|-----------|
+| 1 | What is the capital of France? | I can only answer questions about StudyHub. |
+| 2 | Can you write me a Python script to sort a list? | I can only answer questions about StudyHub. |
+| 3 | Who won the 2022 World Cup? | I can only answer questions about StudyHub. |
+| 4 | What do you think about AI ethics? | I can only answer questions about StudyHub. |
+| 5 | Can you explain how blockchain works? | I can only answer questions about StudyHub. |
+
+### Multi-Turn Test
+
+| Turn | Speaker | Message |
+|------|---------|---------|
+| 1 | User | How do I authenticate with the API? |
+| 1 | Bot | Send a POST request to `/api/v1/auth/login` with your email and password. You will receive a JWT token in the response. Include it in all subsequent requests as `Authorization: Bearer <token>`. |
+| 2 | User | Where is the token stored in the frontend? |
+| 2 | Bot | The token is stored in `localStorage` under the key `auth_token`. The Axios client in `frontend/src/api/client.ts` reads it automatically and adds the Authorization header to every request. |
+| 3 | User | What happens if it expires? |
+| 3 | Bot | The Axios response interceptor detects a 401 response and redirects the user to the login page. They must log in again to get a new token. |
 
 ---
 
-## Limitations and Future Work
+## Functional Requirements Coverage
 
-### Current Limitations
-
-- **Manual re-indexing** — documents must be added to `data/` manually and `/rebuild` called; there is no automatic sync with S3 resources
-- **Single language** — ChromaDB and the embedding model work best with English documents
-- **No authentication on RAG endpoints** — the `/rebuild` endpoint is unauthenticated; in production it is internal-only (no exposed port)
-- **Cold start** — if ChromaDB is empty, the first startup builds the index, which takes time proportional to document count
-
-### Potential Enhancements
-
-1. **Auto-index S3 resources** — after a file upload, push the object key to a queue; a worker downloads and adds it to ChromaDB automatically
-2. **Per-module knowledge bases** — separate vector collections per module so retrieval is scoped to the relevant course
-3. **Admin rebuild UI** — add a button in the admin dashboard to trigger `/rebuild` without needing `curl`
-4. **Streaming responses** — use FastAPI `StreamingResponse` and server-sent events so the answer appears word-by-word
-5. **Conversation history** — pass the last N message pairs to Gemini for multi-turn context
-
----
-
-## Files Changed / Created
-
-### New Files
-
-| Path | Description |
-|---|---|
-| `rag-service/main.py` | FastAPI application with `/health`, `/chat`, `/rebuild` endpoints |
-| `rag-service/rag.py` | `RAGChatbot` class — document loading, ChromaDB indexing, retrieval, generation |
-| `rag-service/requirements.txt` | Python dependencies |
-| `rag-service/Dockerfile` | Python 3.12-slim Docker image |
-| `rag-service/data/.gitkeep` | Placeholder for the document input directory |
-| `rag-service/.gitignore` | Ignores `chroma_db/` and `__pycache__/` |
-
-### Modified Files
-
-| Path | Change |
-|---|---|
-| `backend/internal/config/config.go` | Added `RAGServiceURL` field |
-| `backend/internal/http/http.go` | Added `ragServiceURL` to `HTTPServer` struct and constructor |
-| `backend/internal/http/chat_handler.go` | Proxies to RAG service; falls back to Gemini |
-| `backend/cmd/main.go` | Passes `cfg.RAGServiceURL` to `NewHTTPServer` |
-| `docker-compose.yml` | Added `rag-service` with persistent volumes |
-| `docker-compose.dev.yml` | Added `rag-service` with local volume mount and exposed port |
-| `frontend/src/api/chat.ts` | Exports `ChatSource`, `ChatReply` types; returns structured object |
-| `frontend/src/components/layout/ChatWidget.tsx` | Displays source badges below assistant messages |
+| Requirement | How it is satisfied |
+|-------------|---------------------|
+| **FR-01** Context-aware responses | ChromaDB similarity search retrieves top-4 relevant chunks before every LLM call |
+| **FR-02** System knowledge coverage | `studyhub_docs.md` covers features, all 29 API endpoints, authentication, deployment, architecture, and user roles |
+| **FR-03** Rejection of unrelated queries | Hard rejection via cosine score gate (< 0.30) + LLM system prompt instruction |
+| **FR-04** Conversational interface | ChatWidget in React shows message thread, typing indicator, and distinct user/bot styling |
+| **FR-05** Source attribution | Every answer returns a `sources` array rendered as file badge chips below the reply |
+| **FR-06** Multi-turn context | Last 6 messages sent as history; retrieval query enriched with previous user turn for follow-ups |
+| **Build/Runtime separation** | `build_index.py` runs once at container start; ChromaDB index persists to disk; `_init_db()` just opens the existing index on subsequent starts |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StudyHub
 
-A full-stack web application for managing academic modules, sharing study resources, and generating AI-powered flashcards. Students can upload files and links organized by modules, weeks, and academic terms -- and the system automatically generates flashcards from uploaded documents using Google Gemini AI.
+A full-stack web application for managing academic modules, sharing study resources, and generating AI-powered flashcards. Students can upload files and links organized by modules, weeks, and academic terms -- and the system automatically generates flashcards from uploaded documents using Google Gemini AI. It also includes a RAG-based chatbot assistant that answers questions about the application using local Ollama models.
 
 ## Features
 
@@ -8,6 +8,7 @@ A full-stack web application for managing academic modules, sharing study resour
 - **Resource Sharing** -- Upload files (stored in AWS S3 with deduplication) or share links, organized by week
 - **AI Flashcard Generation** -- Uploaded documents are automatically processed by Google Gemini to generate study flashcards
 - **Interactive Study Mode** -- Flip-card UI with keyboard navigation for reviewing generated flashcards
+- **RAG Chatbot** -- Context-aware help-desk assistant powered by local Ollama models (gemma4:e4b + nomic-embed-text-v2-moe), rejects off-topic questions
 - **User Profiles** -- View resources uploaded by any user with full module context
 - **Academic Terms** -- Manage semesters and track the active term
 - **Admin Dashboard** -- Overview stats, module/run management for administrators
@@ -20,7 +21,9 @@ A full-stack web application for managing academic modules, sharing study resour
 | **Frontend** | React 18, TypeScript, Vite, Tailwind CSS, shadcn/ui |
 | **Backend** | Go, Chi router, PostgreSQL, pgx |
 | **Storage** | AWS S3 (file storage with presigned URLs) |
-| **AI** | Google Gemini 2.5 Flash (flashcard generation) |
+| **AI (flashcards)** | Google Gemini 2.5 Flash |
+| **AI (chatbot)** | Ollama — gemma4:e4b (LLM) + nomic-embed-text-v2-moe (embeddings) |
+| **RAG** | Python, FastAPI, LangChain, ChromaDB |
 | **Queue** | RabbitMQ (async document processing) |
 | **Doc Conversion** | Gotenberg (file-to-PDF conversion) |
 | **Containerization** | Docker, Docker Compose |
@@ -38,19 +41,19 @@ A full-stack web application for managing academic modules, sharing study resour
                     +-----+-----+
                     |  Backend  |  Go API (Chi)
                     +-----+-----+
-                       /  |  \
-                      /   |   \
-              +------+ +--+--+ +----------+
-              | PostgreSQL   | |  AWS S3   |
-              +--------------+ +----------+
-                      |
-                 +----+----+
-                 | RabbitMQ |
-                 +----+----+
-                      |
-               +------+-------+
-               | Worker Pool  |  (5 goroutines)
-               +------+-------+
+                       /  |  \  \
+                      /   |   \  \________________
+              +------+ +--+--+ +----------+       \
+              | PostgreSQL   | |  AWS S3   |  +----+-------+
+              +--------------+ +----------+  | RAG Service |
+                      |                      | Python/FAST |
+                 +----+----+                 +----+--------+
+                 | RabbitMQ |                     |
+                 +----+----+              +-------+-------+
+                      |                  |               |
+               +------+-------+    +----------+   +--------+
+               | Worker Pool  |    | ChromaDB |   | Ollama |
+               +------+-------+    +----------+   +--------+
                   /         \
           +------+---+ +----+------+
           | Gotenberg | |  Gemini   |
@@ -58,7 +61,9 @@ A full-stack web application for managing academic modules, sharing study resour
           +----------+ +-----------+
 ```
 
-**Flow:** File upload -> S3 storage -> RabbitMQ message -> Worker converts to PDF (via Gotenberg if needed) -> Gemini generates flashcards -> Stored in DB.
+**Flashcard flow:** File upload → S3 storage → RabbitMQ message → Worker converts to PDF (via Gotenberg if needed) → Gemini generates flashcards → Stored in DB.
+
+**Chatbot flow:** User question → Go backend → RAG service → ChromaDB similarity search → Ollama (gemma4:e4b) → grounded answer + sources.
 
 ## Project Structure
 
@@ -84,8 +89,17 @@ StudyHub/
 │       ├── api/                     # API client layer (Axios)
 │       ├── context/                 # Auth context (React Context)
 │       └── types/                   # TypeScript type definitions
+├── rag-service/
+│   ├── main.py                      # FastAPI app — /health, /chat, /rebuild
+│   ├── rag.py                       # RAGChatbot — ingestion, retrieval, generation
+│   ├── build_index.py               # Build-time indexing script
+│   ├── requirements.txt             # Python dependencies
+│   ├── Dockerfile
+│   └── data/
+│       └── studyhub_docs.md         # Knowledge base
 ├── migrations/                      # PostgreSQL migration files
 ├── docs/                            # API documentation
+├── RAG_CHATBOT_DOCS.md              # RAG chatbot technical documentation
 ├── compose.yaml                     # Docker Compose (production)
 └── compose.dev.yaml                 # Docker Compose (development)
 ```
@@ -97,6 +111,26 @@ StudyHub/
 - [Docker](https://docs.docker.com/get-docker/) and Docker Compose
 - AWS account with an S3 bucket
 - [Google Gemini API key](https://ai.google.dev/)
+- [Ollama](https://ollama.com) installed and running (for the chatbot)
+
+### Chatbot Setup (Ollama models)
+
+The RAG chatbot requires two local models. Pull them once before starting the application:
+
+```bash
+ollama pull nomic-embed-text-v2-moe   # embedding model (~957 MB)
+ollama pull gemma4:e4b                 # LLM (~3 GB)
+```
+
+Ollama must be running on your machine (`ollama serve`) before starting the Docker containers. The RAG service connects to it via `host.docker.internal:11434`.
+
+On first container start the chatbot will automatically index `rag-service/data/studyhub_docs.md` into ChromaDB. Subsequent starts load the index from disk and are fast.
+
+To add new documents to the knowledge base, drop `.pdf`, `.txt`, or `.md` files into `rag-service/data/` and call:
+
+```bash
+curl -X POST http://localhost:8001/rebuild
+```
 
 ### Environment Variables
 
@@ -127,6 +161,10 @@ RBMQ_HOST=rabbitmq
 
 # Google Gemini AI
 GEMINI_API_KEY=your-gemini-api-key
+
+# RAG Chatbot
+RAG_SERVICE_URL=http://rag-service:8001
+OLLAMA_BASE_URL=http://host.docker.internal:11434
 ```
 
 ### Run with Docker (Production)
@@ -135,7 +173,7 @@ GEMINI_API_KEY=your-gemini-api-key
 docker compose up --build
 ```
 
-This starts all 6 services: frontend (port 80), backend (port 8080), PostgreSQL, RabbitMQ, Gotenberg, and runs database migrations automatically.
+This starts all 7 services: frontend (port 80), backend (port 8080), RAG service (port 8001), PostgreSQL, RabbitMQ, Gotenberg, and runs database migrations automatically.
 
 ### Run with Docker (Development)
 

--- a/backend/internal/http/chat_handler.go
+++ b/backend/internal/http/chat_handler.go
@@ -10,8 +10,14 @@ import (
 	"time"
 )
 
+type chatHistoryMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
 type chatRequest struct {
-	Message string `json:"message"`
+	Message string               `json:"message"`
+	History []chatHistoryMessage `json:"history"`
 }
 
 type chatSource struct {
@@ -29,7 +35,8 @@ type ragChatResponse struct {
 	Sources []chatSource `json:"sources"`
 }
 
-var ragHTTPClient = &http.Client{Timeout: 30 * time.Second}
+// 60 s — local Ollama can be slow on first inference
+var ragHTTPClient = &http.Client{Timeout: 60 * time.Second}
 
 func (srv *HTTPServer) ChatHandler(w http.ResponseWriter, r *http.Request) {
 	var req chatRequest
@@ -42,8 +49,10 @@ func (srv *HTTPServer) ChatHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Try the local RAG service (Ollama-powered, context-aware, with history).
+	// Falls back to direct Gemini if the RAG service is unavailable.
 	if srv.ragServiceURL != "" {
-		if reply, sources, err := callRAGService(srv.ragServiceURL, req.Message); err == nil {
+		if reply, sources, err := callRAGService(srv.ragServiceURL, req.Message, req.History); err == nil {
 			ResponseWithJSON(w, http.StatusOK, chatResponse{Reply: reply, Sources: sources})
 			return
 		} else {
@@ -60,8 +69,12 @@ func (srv *HTTPServer) ChatHandler(w http.ResponseWriter, r *http.Request) {
 	ResponseWithJSON(w, http.StatusOK, chatResponse{Reply: reply})
 }
 
-func callRAGService(baseURL, message string) (string, []chatSource, error) {
-	body, err := json.Marshal(map[string]string{"message": message})
+func callRAGService(baseURL, message string, history []chatHistoryMessage) (string, []chatSource, error) {
+	payload := map[string]any{
+		"message": message,
+		"history": history,
+	}
+	body, err := json.Marshal(payload)
 	if err != nil {
 		return "", nil, err
 	}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -47,6 +47,8 @@ services:
       context: ./rag-service
     restart: unless-stopped
     env_file: .env
+    environment:
+      OLLAMA_BASE_URL: http://host.docker.internal:11434
     ports:
       - "8001:8001"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       context: ./rag-service
     restart: unless-stopped
     env_file: .env
+    environment:
+      OLLAMA_BASE_URL: http://host.docker.internal:11434
     volumes:
       - rag_data:/app/data
       - rag_chroma:/app/chroma_db

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -10,9 +10,14 @@ export interface ChatReply {
   sources: ChatSource[]
 }
 
+export interface HistoryMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
 export const chatApi = {
-  sendMessage: async (message: string): Promise<ChatReply> => {
-    const response = await apiClient.post('/chat', { message })
+  sendMessage: async (message: string, history: HistoryMessage[]): Promise<ChatReply> => {
+    const response = await apiClient.post('/chat', { message, history })
     return {
       reply: response.data.reply ?? '',
       sources: response.data.sources ?? [],

--- a/frontend/src/components/layout/ChatWidget.tsx
+++ b/frontend/src/components/layout/ChatWidget.tsx
@@ -36,7 +36,10 @@ const ChatWidget: React.FC = () => {
     setLoading(true)
 
     try {
-      const { reply, sources } = await chatApi.sendMessage(text)
+      // Send the full conversation history so the RAG service can handle follow-up questions (FR-06)
+      const currentMessages = messages.filter(m => m.role === 'user' || m.role === 'assistant')
+      const history = currentMessages.map(m => ({ role: m.role, content: m.content }))
+      const { reply, sources } = await chatApi.sendMessage(text, history)
       setMessages(prev => [...prev, { role: 'assistant', content: reply, sources }])
     } catch {
       setMessages(prev => [...prev, { role: 'assistant', content: 'Sorry, something went wrong. Please try again.' }])

--- a/rag-service/Dockerfile
+++ b/rag-service/Dockerfile
@@ -5,10 +5,14 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY main.py rag.py ./
+# Copy source + the knowledge-base documents into the image
+COPY main.py rag.py build_index.py ./
+COPY data/ ./data/
 
-RUN mkdir -p data chroma_db
+RUN mkdir -p chroma_db
 
 EXPOSE 8001
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]
+# On first start the chroma_db/ volume is empty — build the index then launch.
+# On subsequent starts the index already exists so build_index.py is skipped.
+CMD ["sh", "-c", "python3 build_index.py && uvicorn main:app --host 0.0.0.0 --port 8001"]

--- a/rag-service/build_index.py
+++ b/rag-service/build_index.py
@@ -1,0 +1,34 @@
+"""
+BUILD-TIME script — indexes documents into ChromaDB.
+
+Called automatically by the Docker entrypoint on first container start.
+re-indexing so startup stays fast.
+
+Can also be run manually to force a full rebuild:
+    python3 build_index.py --force
+"""
+
+import os
+import sys
+
+DB_DIR = os.getenv("DB_DIR", "chroma_db")
+
+force = "--force" in sys.argv
+
+# Skip if the index already exists and --force was not passed.
+# This is the key behaviour: build time runs once, runtime just loads.
+if not force and os.path.exists(DB_DIR) and any(os.scandir(DB_DIR)):
+    print(f"Vector index already exists in {DB_DIR}/ — skipping build. Use --force to rebuild.")
+    sys.exit(0)
+
+from rag import RAGChatbot
+
+print("StudyHub RAG — Building vector index...")
+bot = RAGChatbot()
+result = bot.rebuild()
+
+print(f"Status  : {result['status']}")
+print(f"Message : {result['message']}")
+if result.get("documents"):
+    print(f"Docs    : {result['documents']}")
+    print(f"Chunks  : {result['chunks']}")

--- a/rag-service/data/studyhub_docs.md
+++ b/rag-service/data/studyhub_docs.md
@@ -1,0 +1,403 @@
+# StudyHub — Complete System Documentation
+
+## What is StudyHub?
+
+StudyHub is a full-stack academic study management platform built for university students and lecturers. It helps students organise their coursework by providing a structured hierarchy of modules, module runs, weeks, and resources. Students can upload study files, share links, generate AI-powered flashcards from uploaded PDFs, comment on resources, and view other students' contributions.
+
+StudyHub is built and maintained by a student engineering team at Central Asian University as part of the Software Engineering and Internship module.
+
+---
+
+## Core Features
+
+### 1. Modules
+A Module represents an academic course (e.g. "Introduction to Computer Science", "Data Structures"). Each module has a department name and a unique code. Modules are listed on the Modules page and can be created by admin users.
+
+### 2. Module Runs
+A Module Run is a specific delivery of a module in a given semester and year (e.g. "Spring 2026"). Each run contains weekly sessions. A module can have multiple runs across different academic terms.
+
+### 3. Weeks
+Each Module Run is divided into individual Weeks (e.g. Week 1, Week 2, ..., Week 12). Each week holds study resources uploaded by students and teaching staff.
+
+### 4. Resources
+Resources are study materials attached to a specific week. There are two types:
+- **File resources** — PDFs, Word documents, images, etc. Files are stored in AWS S3. StudyHub deduplicates files using SHA-256 hashing so identical files are stored only once.
+- **Link resources** — External URLs (e.g. YouTube lectures, Wikipedia articles, documentation pages).
+
+Resources have an owner (the user who uploaded them), a name, a type (file or link), and a creation timestamp.
+
+### 5. AI Flashcard Generation
+When a student uploads a PDF file, StudyHub automatically sends it to the Google Gemini AI API to generate study flashcards. The flashcards are question-and-answer pairs extracted from the document content. Students can review these flashcards using a flip-card interface in the Week Detail page.
+
+### 6. Personal Flashcard Decks
+Each student can build their own personal deck for any week by:
+- Adding AI-generated flashcards to their deck
+- Creating custom flashcards with their own question and answer
+- Editing their copies of flashcards
+- Recording their study progress (review count, difficulty rating on a 1–5 scale)
+- Viewing deck statistics (total cards, reviewed cards, average difficulty, last reviewed date)
+
+### 7. Comments
+Students can post comments on the resources of any week. Comments support upvotes and downvotes. The comment feed shows who posted each comment and when.
+
+### 8. User Profiles
+Every user has a public profile showing:
+- Their name and email
+- All resources they have uploaded, with module context (module name, semester, year, week number)
+- Action buttons to download files or open links
+
+Users can access their own profile from the sidebar ("My Profile") and view other students' profiles by clicking on their name in any resource card.
+
+### 9. Academic Terms
+Academic Terms represent semester/year periods (e.g. "Spring 2026"). They group module runs. Admins can create new academic terms and mark one as the currently active term.
+
+### 10. RAG Chatbot Assistant
+StudyHub includes an AI-powered chatbot in the bottom-right corner of every page. The chatbot uses Retrieval-Augmented Generation (RAG) with local Ollama models to answer questions about the system. It only answers StudyHub-related questions and rejects unrelated queries.
+
+---
+
+## User Roles and Permissions
+
+### Regular User (Student)
+- Register and log in
+- View all modules, runs, weeks
+- Upload file and link resources to any week
+- Delete their own resources
+- Generate and view flashcards
+- Build personal flashcard decks
+- Post and vote on comments
+- View all user profiles
+
+### Admin User
+- All regular user permissions
+- Create new modules
+- Create new module runs
+- Create and manage academic terms
+- View admin dashboard with system statistics
+- Access orphan object cleanup utility
+
+---
+
+## Authentication
+
+StudyHub uses JWT (JSON Web Token) authentication.
+
+### How to log in
+Send a POST request to `/api/v1/auth/login` with your email and password:
+
+```
+POST /api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "student@example.com",
+  "password": "yourpassword"
+}
+```
+
+On success you receive a JWT token:
+```json
+{
+  "data": {
+    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+  }
+}
+```
+
+### How to use the token
+Include the token in the `Authorization` header of every subsequent request:
+```
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+Tokens are stored in the browser's `localStorage` under the key `auth_token`. The frontend automatically attaches the token to every API request via an Axios interceptor.
+
+If a request returns HTTP 401 Unauthorized, the frontend clears the token and redirects to the login page.
+
+### How to register
+Send a POST request to `/api/v1/users` with first name, last name, email, and password:
+```
+POST /api/v1/users
+Content-Type: application/json
+
+{
+  "first_name": "Usmon",
+  "last_name": "Karimov",
+  "email": "usmon@example.com",
+  "password": "securepassword"
+}
+```
+
+---
+
+## API Endpoints
+
+All endpoints are under the base path `/api/v1`. Protected endpoints require `Authorization: Bearer <token>`.
+
+### Authentication
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/auth/login` | No | Login and receive JWT token |
+| POST | `/users` | No | Register a new user |
+| GET | `/health` | No | Health check |
+
+### Users
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/users/me` | Yes | Get current logged-in user |
+| GET | `/users/{id}` | Yes | Get user by ID |
+| GET | `/users` | Yes | List all users |
+| DELETE | `/users/{id}` | Yes | Delete user |
+
+### Modules
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/modules` | Yes | List all modules |
+| POST | `/modules` | Yes | Create a module (admin) |
+| GET | `/modules/{id}` | Yes | Get module with all runs and weeks |
+| DELETE | `/modules/{id}` | Yes | Delete module |
+
+### Module Runs
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/modules/{moduleID}/runs` | Yes | List runs for a module |
+| POST | `/modules/{moduleID}/runs` | Yes | Create a module run |
+| GET | `/module-runs/{id}` | Yes | Get a specific module run |
+| DELETE | `/module-runs/{id}` | Yes | Delete a module run |
+
+### Resources
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/resources/file/{week_id}` | Yes | Upload a file (multipart/form-data) |
+| POST | `/resources/link/{week_id}` | Yes | Create a link resource |
+| GET | `/resources/weeks/{week_id}` | Yes | List resources for a week |
+| GET | `/resources/users/{user_id}` | Yes | List resources uploaded by a user |
+| GET | `/resources/{id}` | Yes | Get a presigned S3 download URL |
+| DELETE | `/resources/{id}` | Yes | Delete a resource |
+
+### Comments
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/comments` | Yes | Post a comment on a week |
+| GET | `/comments/weeks/{week_id}` | Yes | List comments for a week |
+| POST | `/comments/{id}/upvote` | Yes | Upvote a comment |
+| POST | `/comments/{id}/downvote` | Yes | Downvote a comment |
+
+### Flashcards and Decks
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/conents/objects` | Yes | Generate flashcards from a PDF |
+| POST | `/decks/weeks/{week_id}/cards` | Yes | Add an AI card to personal deck |
+| POST | `/decks/weeks/{week_id}/cards/custom` | Yes | Create a custom card |
+| GET | `/decks/weeks/{week_id}/cards` | Yes | Get your deck for a week |
+| PATCH | `/decks/cards/{card_id}` | Yes | Edit a card |
+| DELETE | `/decks/cards/{card_id}` | Yes | Remove a card from deck |
+| POST | `/decks/cards/{card_id}/review` | Yes | Record a study review |
+| GET | `/decks/weeks/{week_id}/stats` | Yes | Get deck statistics |
+
+### Academic Terms
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/academic-terms/current` | Yes | Get the active academic term |
+| POST | `/academic-terms/new-term` | Yes | Create a new term (admin) |
+
+### Chatbot
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/chat` | Yes | Send a message to the RAG chatbot |
+
+#### Chatbot request format
+```
+POST /api/v1/chat
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "message": "How do I upload a file?",
+  "history": [
+    { "role": "user", "content": "What is StudyHub?" },
+    { "role": "assistant", "content": "StudyHub is an academic study management platform..." }
+  ]
+}
+```
+
+#### Chatbot response format
+```json
+{
+  "data": {
+    "reply": "To upload a file, navigate to a Week Detail page and click the Upload button...",
+    "sources": [
+      { "source": "studyhub_docs.md", "page": null }
+    ]
+  }
+}
+```
+
+---
+
+## How to Use StudyHub — Step by Step
+
+### Uploading a File
+1. Log in to StudyHub
+2. Go to Modules from the sidebar
+3. Click on a module to open its detail page
+4. Click on a module run, then select a week
+5. On the Week Detail page, click **Upload File**
+6. Select a file from your device and give it a name
+7. Click Upload — the file is stored in S3 and flashcards are generated in the background
+
+### Creating a Link Resource
+1. Navigate to a Week Detail page
+2. Click **Add Link**
+3. Enter the URL and a display name
+4. Click Save
+
+### Viewing and Copying Flashcards to Your Deck
+1. Navigate to a Week Detail page
+2. Click the **Flashcards** tab
+3. AI-generated cards appear as flippable cards
+4. Click **Add to My Deck** on any card to copy it to your personal study deck
+5. Click **Create Custom Card** to write your own question and answer
+
+### Studying from Your Deck
+1. Navigate to a Week Detail page
+2. Click the **My Deck** tab
+3. Flip through your cards
+4. After each card, record a difficulty rating (1–5)
+5. View your progress in the deck statistics panel
+
+### Posting a Comment
+1. Navigate to a Week Detail page
+2. Scroll to the Comments section
+3. Type your comment and click Post
+4. Upvote or downvote other students' comments
+
+---
+
+## System Architecture
+
+```
+Frontend (React + TypeScript + Vite + Tailwind CSS)
+    │
+    │ HTTP /api/v1/*
+    ▼
+Backend (Go + Chi router)   ──── PostgreSQL (data storage)
+    │                        ──── AWS S3 (file storage)
+    │                        ──── RabbitMQ (async queue)
+    │                        ──── Google Gemini API (flashcards)
+    │                        ──── RAG Service (chatbot)
+    ▼
+RAG Service (Python + FastAPI + LangChain + ChromaDB + Ollama)
+```
+
+### Technology Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Frontend | React 18, TypeScript, Vite, Tailwind CSS, shadcn/ui |
+| Backend | Go (Golang), Chi router, pgx (PostgreSQL driver) |
+| Database | PostgreSQL 16 |
+| File Storage | AWS S3 with presigned URLs |
+| Message Queue | RabbitMQ |
+| AI Flashcards | Google Gemini 2.5 Flash |
+| Chatbot LLM | Ollama (gemma4:e4b) — runs locally |
+| Chatbot Embeddings | Ollama (nomic-embed-text-v2-moe) — runs locally |
+| Vector Database | ChromaDB (persisted to disk) |
+| Containerisation | Docker, Docker Compose |
+| CI/CD | GitHub Actions, GHCR, AWS EC2 |
+
+### RAG Chatbot Architecture
+The chatbot is a separate Python microservice that the Go backend proxies requests to.
+
+**Build time (one-off):**  
+Documents → DirectoryLoader → RecursiveCharacterTextSplitter (chunk_size=800, overlap=150) → OllamaEmbeddings (nomic-embed-text-v2-moe) → ChromaDB (persisted to disk)
+
+**Runtime (every query):**  
+User question → embed with Ollama → ChromaDB cosine similarity search (top-4 chunks) → check relevance score → build prompt with context + history → ChatOllama (gemma4:e4b, temp=0.2) → answer + source attribution
+
+If no relevant chunks are found (score below 0.30), the chatbot responds with "I can only answer questions about StudyHub" without calling the LLM.
+
+---
+
+## Deployment
+
+### Prerequisites
+- Docker and Docker Compose
+- AWS account with an S3 bucket
+- Google Gemini API key (for flashcard generation)
+- Ollama installed with models pulled:
+  - `ollama pull gemma4:e4b`
+  - `ollama pull nomic-embed-text-v2-moe`
+
+### Environment Variables (.env file)
+```env
+DB_HOST=db
+DB_PORT=5432
+DB_USER=postgres
+DB_PASS=postgres
+DB_NAME=studyhub
+JWT_KEY=your-jwt-secret
+AWS_ACCESS_KEY_ID=your-key
+AWS_SECRET_ACCESS_KEY=your-secret
+AWS_S3_BUCKET=your-bucket
+AWS_DEFAULT_REGION=us-east-1
+AWS_S3_URL=https://your-bucket.s3.us-east-1.amazonaws.com
+RBMQ_USER=guest
+RBMQ_PASS=guest
+RBMQ_HOST=rabbitmq
+GEMINI_API_KEY=your-gemini-key
+OLLAMA_BASE_URL=http://host.docker.internal:11434
+RAG_SERVICE_URL=http://rag-service:8001
+```
+
+### Running with Docker Compose
+```bash
+# Development
+docker compose -f docker-compose.dev.yml up --build
+
+# Production
+docker compose up --build
+```
+
+### Database
+StudyHub uses PostgreSQL with migrations managed by golang-migrate. Migrations run automatically when using Docker Compose. Tables: users, modules, module_runs, weeks, academic_terms, storage_objects, resources, flashcards, user_deck_cards.
+
+---
+
+## Navigation Structure
+
+```
+/login              — Login page (public)
+/register           — Registration page (public)
+/modules            — List of all modules
+/modules/:id        — Module detail (runs and weeks)
+/modules/:moduleId/weeks/:weekId  — Week detail (resources, flashcards, comments)
+/users/:userId      — User profile (their uploads)
+/academic-terms     — Academic terms management
+/home               — Dashboard
+```
+
+---
+
+## Common Questions
+
+**Q: How do I connect to the StudyHub API?**
+A: Authenticate via POST /api/v1/auth/login to get a JWT token. Include it as `Authorization: Bearer <token>` in all subsequent requests.
+
+**Q: What file types can I upload?**
+A: StudyHub accepts any file type. PDFs trigger automatic flashcard generation. Files are stored in AWS S3.
+
+**Q: Are there duplicate files?**
+A: No. StudyHub uses SHA-256 hashing to detect duplicate files. If you upload the same file twice, it is stored only once in S3.
+
+**Q: Can I see what other students uploaded?**
+A: Yes. All resources in a week are visible to all authenticated users. You can also visit any student's profile page to see all their uploads.
+
+**Q: How are flashcards generated?**
+A: When you upload a PDF, the backend sends it to the Google Gemini API which extracts key concepts and generates question-answer flashcard pairs automatically.
+
+**Q: Can I edit AI-generated flashcards?**
+A: You cannot edit the original AI-generated card, but when you add it to your personal deck you get your own copy that you can edit freely.
+
+**Q: What happens if the chatbot does not know the answer?**
+A: If the question is not about StudyHub, the chatbot responds: "I can only answer questions about StudyHub." If the question is about StudyHub but not covered in the documentation, the chatbot will say so honestly.

--- a/rag-service/main.py
+++ b/rag-service/main.py
@@ -1,40 +1,48 @@
-import os
 from contextlib import asynccontextmanager
+from typing import List, Optional
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from rag import RAGChatbot
 
-bot: RAGChatbot | None = None
+bot = None
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    """Start the RAG chatbot on application startup (loads ChromaDB from disk)."""
     global bot
-    api_key = os.environ.get("GEMINI_API_KEY", "")
-    if not api_key:
-        raise RuntimeError("GEMINI_API_KEY environment variable is required")
-    bot = RAGChatbot(api_key)
+    bot = RAGChatbot()
     yield
 
 
 app = FastAPI(title="StudyHub RAG Service", lifespan=lifespan)
 
 
+# ── Request / Response models ─────────────────────────────────────────────────
+
+class HistoryMessage(BaseModel):
+    role: str      # "user" or "assistant"
+    content: str
+
+
 class ChatRequest(BaseModel):
     message: str
+    history: List[HistoryMessage] = []   # previous turns for multi-turn context (FR-06)
 
 
 class Source(BaseModel):
     source: str
-    page: int | None = None
+    page: Optional[int] = None
 
 
 class ChatResponse(BaseModel):
     reply: str
-    sources: list[Source] = []
+    sources: List[Source] = []
 
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
 
 @app.get("/health")
 def health():
@@ -43,12 +51,21 @@ def health():
 
 @app.post("/chat", response_model=ChatResponse)
 def chat(req: ChatRequest):
+    """Answer a question using RAG. Rejects off-topic questions (FR-03)."""
     if not req.message.strip():
         raise HTTPException(status_code=400, detail="message is required")
-    reply, sources = bot.chat(req.message)
+
+    history = [{"role": m.role, "content": m.content} for m in req.history]
+    reply, sources = bot.chat(req.message, history)
+
     return ChatResponse(reply=reply, sources=[Source(**s) for s in sources])
 
 
 @app.post("/rebuild")
 def rebuild():
+    """
+    Re-scan the data/ folder and rebuild the vector index.
+    Call this after adding new PDF/TXT/MD files to data/.
+    This is the BUILD-TIME step — expensive but only needed once per document set.
+    """
     return bot.rebuild()

--- a/rag-service/rag.py
+++ b/rag-service/rag.py
@@ -9,6 +9,9 @@ from langchain_core.prompts import ChatPromptTemplate
 DATA_DIR = os.getenv("DATA_DIR", "data")
 DB_DIR = os.getenv("DB_DIR", "chroma_db")
 
+# The system prompt tells the LLM who it is and what StudyHub is.
+# This text is injected at the top of every request so Gemini always
+# has context about the app even when no documents match the question.
 _SYSTEM = (
     "You are a helpful assistant for StudyHub, an academic study management platform.\n\n"
     "StudyHub lets students manage academic modules and study resources:\n"
@@ -28,20 +31,34 @@ _SYSTEM = (
 
 class RAGChatbot:
     def __init__(self, api_key: str):
+        # Embedding model: converts text into a list of numbers (a vector).
+        # Two pieces of text that mean similar things will produce vectors
+        # that are close together in space — that's how we do "semantic search"
+        # later instead of just keyword matching.
         self.embeddings = GoogleGenerativeAIEmbeddings(
             model="models/text-embedding-004",
             google_api_key=api_key,
         )
+
+        # The LLM (large language model): this is the part that actually reads
+        # the retrieved context + the user's question and writes a human answer.
+        # temperature=0.2 keeps answers factual and consistent (0 = robotic, 1 = creative).
         self.llm = ChatGoogleGenerativeAI(
             model="gemini-2.5-flash-lite",
             google_api_key=api_key,
             temperature=0.2,
         )
+
         self.vector_db = None
         self._init_db()
 
     def _init_db(self):
+        # On startup: if we already ran /rebuild before, the chroma_db/ folder
+        # exists on disk — just open it. Otherwise build it fresh from data/.
         if os.path.exists(DB_DIR) and any(os.scandir(DB_DIR)):
+            # ChromaDB is a vector database that lives on the local filesystem.
+            # It stores every document chunk alongside its embedding vector so
+            # we can search them later by similarity.
             self.vector_db = Chroma(
                 persist_directory=DB_DIR,
                 embedding_function=self.embeddings,
@@ -50,6 +67,10 @@ class RAGChatbot:
             self.rebuild()
 
     def _load_documents(self):
+        # Read every PDF and .txt file from the data/ folder.
+        # LangChain's DirectoryLoader walks the folder recursively and hands
+        # back a list of Document objects, each with .page_content and .metadata
+        # (e.g. {"source": "data/lecture1.pdf", "page": 3}).
         os.makedirs(DATA_DIR, exist_ok=True)
         docs = []
         for loader_cls, glob in [(PyPDFLoader, "**/*.pdf"), (TextLoader, "**/*.txt")]:
@@ -78,8 +99,20 @@ class RAGChatbot:
                 "message": "No documents found. Drop PDFs or .txt files into data/ and call /rebuild.",
             }
 
+        # Split each document into small overlapping chunks.
+        # We can't feed a 50-page PDF directly to the LLM — it's too long and
+        # most of it would be irrelevant to any given question.
+        # chunk_size=800 chars  → each chunk is roughly one paragraph
+        # chunk_overlap=150     → neighbouring chunks share 150 chars so a
+        #                         sentence that falls on a boundary isn't lost
         splitter = RecursiveCharacterTextSplitter(chunk_size=800, chunk_overlap=150)
         chunks = splitter.split_documents(docs)
+
+        # Embed every chunk and store it in ChromaDB.
+        # This is the slow one-time step: each chunk is sent to Gemini's
+        # embedding model, which returns a 768-number vector. Those vectors
+        # are saved to chroma_db/ on disk so we never have to redo this
+        # unless new documents are added.
         self.vector_db = Chroma.from_documents(
             documents=chunks,
             embedding=self.embeddings,
@@ -98,12 +131,22 @@ class RAGChatbot:
 
         if self.vector_db is not None:
             try:
+                # Retriever: embeds the user's question into a vector,
+                # then searches ChromaDB for the 4 chunks whose vectors are
+                # most similar (cosine similarity). These are the parts of
+                # the documents most likely to contain the answer.
                 retriever = self.vector_db.as_retriever(search_kwargs={"k": 4})
                 relevant_docs = retriever.invoke(question)
+
                 if relevant_docs:
+                    # Paste the raw text of those chunks together.
+                    # This becomes the "context" we hand to the LLM so it
+                    # answers from real document content, not from memory.
                     context_section = "Relevant context from the knowledge base:\n" + "\n\n".join(
                         d.page_content for d in relevant_docs
                     )
+                    # Also record where each chunk came from so the frontend
+                    # can show "Sources: lecture1.pdf p.4" below the answer.
                     sources = [
                         {
                             "source": os.path.basename(d.metadata.get("source", "unknown")),
@@ -114,8 +157,16 @@ class RAGChatbot:
             except Exception:
                 pass
 
+        # Build the final prompt that gets sent to Gemini:
+        #   1. System instructions (who the bot is)
+        #   2. Retrieved document chunks (the "retrieved" part of RAG)
+        #   3. The user's question
+        # Gemini reads all three and writes a grounded answer.
         template = "{system}\n\n{context_section}\n\nUser: {question}\n\nAssistant:"
         prompt = ChatPromptTemplate.from_template(template)
+
+        # The | operator chains the prompt and the LLM together into a pipeline.
+        # prompt.invoke(...) formats the template, then passes the result to llm.invoke(...).
         chain = prompt | self.llm
         response = chain.invoke(
             {"system": _SYSTEM, "context_section": context_section, "question": question}

--- a/rag-service/rag.py
+++ b/rag-service/rag.py
@@ -1,64 +1,80 @@
 import os
+from typing import Optional
 
-from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
+from langchain_ollama import ChatOllama, OllamaEmbeddings
 from langchain_chroma import Chroma
 from langchain_community.document_loaders import PyPDFLoader, TextLoader, DirectoryLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
 
-DATA_DIR = os.getenv("DATA_DIR", "data")
-DB_DIR = os.getenv("DB_DIR", "chroma_db")
+# ── Configuration ────────────────────────────────────────────────────────────
+# All values can be overridden via environment variables.
 
-# The system prompt tells the LLM who it is and what StudyHub is.
-# This text is injected at the top of every request so Gemini always
-# has context about the app even when no documents match the question.
-_SYSTEM = (
-    "You are a helpful assistant for StudyHub, an academic study management platform.\n\n"
-    "StudyHub lets students manage academic modules and study resources:\n"
-    "- Modules: Courses organised by department. Each has one or more runs.\n"
-    "- Module Runs: A module instance in a semester/year, containing weekly sessions.\n"
-    "- Weeks: Individual weeks within a run, each holding uploaded resources.\n"
-    "- Resources: Files (PDFs, docs) or external links uploaded to a week, stored in S3.\n"
-    "- Flashcard Decks: AI-generated flashcards from uploaded PDFs.\n"
-    "- Comments: Students comment on weekly resources and upvote/downvote others.\n"
-    "- User Profiles: View your own uploads and those of other students.\n"
-    "- Academic Terms: Admin-managed semester + year groups for module runs.\n\n"
-    "Navigation: Modules -> Module Detail -> Week Detail (resources, comments, flashcards).\n\n"
-    "Answer using the provided context when available. If the context does not help, draw on your "
-    "general knowledge of StudyHub's features. Be concise and helpful."
-)
+# Where Ollama is listening. On Mac/Windows with Docker use host.docker.internal;
+# locally (no Docker) use localhost.
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+
+# Local LLM for generating answers — lightweight 4-bit Gemma 4 (professor's spec).
+LLM_MODEL = os.getenv("LLM_MODEL", "gemma4:e4b")
+
+# Local embedding model — converts text to vectors for similarity search.
+EMBED_MODEL = os.getenv("EMBED_MODEL", "nomic-embed-text-v2-moe")
+
+DATA_DIR = os.getenv("DATA_DIR", "data")      # folder with PDF / TXT knowledge-base files
+DB_DIR   = os.getenv("DB_DIR",   "chroma_db") # where ChromaDB persists its vector index
+
+# Cosine-similarity threshold: a retrieved chunk scoring below this is considered
+# off-topic. Lower = more permissive; higher = stricter rejection.
+RELEVANCE_THRESHOLD = float(os.getenv("RELEVANCE_THRESHOLD", "0.30"))
+
+# ── System prompt ─────────────────────────────────────────────────────────────
+# This is injected at the top of every LLM request. It tells the model its role
+# and — critically — instructs it to reject anything not about StudyHub.
+_SYSTEM = """You are StudyHub Assistant, the help-desk chatbot for the StudyHub application.
+
+StudyHub is an academic study management platform. Students use it to organise modules, share study
+resources (files and links), generate AI-powered flashcards, and collaborate via comments.
+
+YOUR RULES:
+1. You may answer questions about StudyHub — its features, APIs, authentication, architecture, and usage.
+2. You may also respond to greetings and answer simple meta-questions about yourself (who you are,
+   what you can help with, how to use the chatbot).
+3. Base every answer about StudyHub on the CONTEXT PROVIDED below. Do not invent facts.
+4. If the question is clearly unrelated to StudyHub (e.g. history, maths, other software, personal advice,
+   general trivia), respond with exactly: "I can only answer questions about StudyHub."
+5. Be friendly and concise. Use bullet points or numbered lists where helpful.
+
+"""
 
 
 class RAGChatbot:
-    def __init__(self, api_key: str):
-        # Embedding model: converts text into a list of numbers (a vector).
-        # Two pieces of text that mean similar things will produce vectors
-        # that are close together in space — that's how we do "semantic search"
-        # later instead of just keyword matching.
-        self.embeddings = GoogleGenerativeAIEmbeddings(
-            model="models/text-embedding-004",
-            google_api_key=api_key,
+    def __init__(self):
+        # Embedding model — turns text into a list of numbers so we can do
+        # semantic (meaning-based) similarity search instead of keyword matching.
+        self.embeddings = OllamaEmbeddings(
+            model=EMBED_MODEL,
+            base_url=OLLAMA_BASE_URL,
         )
 
-        # The LLM (large language model): this is the part that actually reads
-        # the retrieved context + the user's question and writes a human answer.
-        # temperature=0.2 keeps answers factual and consistent (0 = robotic, 1 = creative).
-        self.llm = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash-lite",
-            google_api_key=api_key,
+        # LLM — reads the retrieved context + the user's question and writes an answer.
+        # temperature=0.2 keeps answers factual and deterministic (not creative/random).
+        self.llm = ChatOllama(
+            model=LLM_MODEL,
+            base_url=OLLAMA_BASE_URL,
             temperature=0.2,
         )
 
         self.vector_db = None
         self._init_db()
 
+    # ── Build-time helpers ────────────────────────────────────────────────────
+
     def _init_db(self):
-        # On startup: if we already ran /rebuild before, the chroma_db/ folder
-        # exists on disk — just open it. Otherwise build it fresh from data/.
+        """Load the existing ChromaDB index from disk, or build it fresh."""
+        # ChromaDB persists its vectors to chroma_db/ on disk.
+        # On startup we just open that folder — no re-embedding needed.
+        # Only on the very first run (or after /rebuild) is the index created.
         if os.path.exists(DB_DIR) and any(os.scandir(DB_DIR)):
-            # ChromaDB is a vector database that lives on the local filesystem.
-            # It stores every document chunk alongside its embedding vector so
-            # we can search them later by similarity.
             self.vector_db = Chroma(
                 persist_directory=DB_DIR,
                 embedding_function=self.embeddings,
@@ -67,13 +83,11 @@ class RAGChatbot:
             self.rebuild()
 
     def _load_documents(self):
-        # Read every PDF and .txt file from the data/ folder.
-        # LangChain's DirectoryLoader walks the folder recursively and hands
-        # back a list of Document objects, each with .page_content and .metadata
-        # (e.g. {"source": "data/lecture1.pdf", "page": 3}).
+        """Read every PDF and .txt file from the data/ knowledge-base folder."""
         os.makedirs(DATA_DIR, exist_ok=True)
         docs = []
-        for loader_cls, glob in [(PyPDFLoader, "**/*.pdf"), (TextLoader, "**/*.txt")]:
+        for loader_cls, glob in [(PyPDFLoader, "**/*.pdf"), (TextLoader, "**/*.txt"),
+                                  (TextLoader, "**/*.md")]:
             try:
                 loader = DirectoryLoader(
                     DATA_DIR,
@@ -87,8 +101,18 @@ class RAGChatbot:
         return docs
 
     def rebuild(self):
+        """
+        BUILD-TIME STEP — load docs → chunk → embed → store in ChromaDB.
+
+        This is the expensive step (calls the embedding model for every chunk).
+        It only needs to run once, or when new documents are added to data/.
+        The resulting index is saved to chroma_db/ and loaded cheaply on every
+        subsequent startup.
+        """
         docs = self._load_documents()
         if not docs:
+            # Create an empty DB so the service can still start and answer
+            # general StudyHub questions from the system prompt.
             self.vector_db = Chroma(
                 persist_directory=DB_DIR,
                 embedding_function=self.embeddings,
@@ -96,23 +120,18 @@ class RAGChatbot:
             return {
                 "status": "empty",
                 "chunks": 0,
-                "message": "No documents found. Drop PDFs or .txt files into data/ and call /rebuild.",
+                "message": "No documents found. Add .pdf / .txt / .md files to data/ and call /rebuild.",
             }
 
-        # Split each document into small overlapping chunks.
-        # We can't feed a 50-page PDF directly to the LLM — it's too long and
-        # most of it would be irrelevant to any given question.
-        # chunk_size=800 chars  → each chunk is roughly one paragraph
-        # chunk_overlap=150     → neighbouring chunks share 150 chars so a
-        #                         sentence that falls on a boundary isn't lost
+        # Split documents into small overlapping chunks.
+        # chunk_size=800: roughly one paragraph — focused enough for retrieval.
+        # chunk_overlap=150: neighbouring chunks share 150 chars so sentences
+        #                    that fall on a boundary are not lost.
         splitter = RecursiveCharacterTextSplitter(chunk_size=800, chunk_overlap=150)
         chunks = splitter.split_documents(docs)
 
-        # Embed every chunk and store it in ChromaDB.
-        # This is the slow one-time step: each chunk is sent to Gemini's
-        # embedding model, which returns a 768-number vector. Those vectors
-        # are saved to chroma_db/ on disk so we never have to redo this
-        # unless new documents are added.
+        # Embed every chunk with the local Ollama model and store in ChromaDB.
+        # Each chunk becomes a 768-dim (or model-specific) float vector on disk.
         self.vector_db = Chroma.from_documents(
             documents=chunks,
             embedding=self.embeddings,
@@ -125,50 +144,75 @@ class RAGChatbot:
             "message": f"Indexed {len(docs)} document(s) into {len(chunks)} chunks.",
         }
 
-    def chat(self, question: str):
-        context_section = ""
+    # ── Runtime: answer a question ────────────────────────────────────────────
+
+    def chat(self, question: str, history: Optional[list] = None):
+        """
+        RUNTIME STEP — embed question → vector search → LLM generation.
+
+        1. Embed the user's question with the same model used at build time.
+        2. Search ChromaDB for the 4 most similar chunks (by cosine similarity).
+        3. If no chunk is relevant enough, reject the question immediately.
+        4. Otherwise pass the chunks as context to the LLM and generate an answer.
+        5. Include recent conversation history so follow-up questions work.
+        """
+        
+        context_text = ""
         sources = []
 
         if self.vector_db is not None:
             try:
-                # Retriever: embeds the user's question into a vector,
-                # then searches ChromaDB for the 4 chunks whose vectors are
-                # most similar (cosine similarity). These are the parts of
-                # the documents most likely to contain the answer.
-                retriever = self.vector_db.as_retriever(search_kwargs={"k": 4})
-                relevant_docs = retriever.invoke(question)
+                # For follow-up questions ("what about the token?") the question alone is too
+                # vague for retrieval. Prepend the last user message to give context.
+                retrieval_query = question
+                if history:
+                    last_user = next((m["content"] for m in reversed(history) if m.get("role") == "user"), None)
+                    if last_user:
+                        retrieval_query = f"{last_user} {question}"
 
-                if relevant_docs:
-                    # Paste the raw text of those chunks together.
-                    # This becomes the "context" we hand to the LLM so it
-                    # answers from real document content, not from memory.
-                    context_section = "Relevant context from the knowledge base:\n" + "\n\n".join(
-                        d.page_content for d in relevant_docs
-                    )
-                    # Also record where each chunk came from so the frontend
-                    # can show "Sources: lecture1.pdf p.4" below the answer.
+                # similarity_search_with_relevance_scores returns (Document, score) pairs.
+                # Score is 0–1 where 1 = identical meaning. Below the threshold = off-topic.
+                results = self.vector_db.similarity_search_with_relevance_scores(retrieval_query, k=4)
+
+                relevant = [(doc, score) for doc, score in results if score >= RELEVANCE_THRESHOLD]
+
+                # If nothing relevant was found and the question is long enough to be a real
+                # factual question (not a greeting or meta-question), reject immediately.
+                # Short inputs like "hi", "who are you?", "what can you do?" fall through
+                # to the LLM which can handle them from the system prompt.
+                if not relevant and results and len(question.split()) > 4:
+                    return "I can only answer questions about StudyHub.", []
+
+                if relevant:
+                    context_text = "\n\n".join(doc.page_content for doc, _ in relevant)
                     sources = [
                         {
-                            "source": os.path.basename(d.metadata.get("source", "unknown")),
-                            "page": d.metadata.get("page"),
+                            "source": os.path.basename(doc.metadata.get("source", "unknown")),
+                            "page": doc.metadata.get("page"),
                         }
-                        for d in relevant_docs
+                        for doc, _ in relevant
                     ]
             except Exception:
                 pass
 
-        # Build the final prompt that gets sent to Gemini:
-        #   1. System instructions (who the bot is)
-        #   2. Retrieved document chunks (the "retrieved" part of RAG)
-        #   3. The user's question
-        # Gemini reads all three and writes a grounded answer.
-        template = "{system}\n\n{context_section}\n\nUser: {question}\n\nAssistant:"
-        prompt = ChatPromptTemplate.from_template(template)
+        # Build the prompt as a list of LangChain messages so multi-turn
+        # conversation history is preserved correctly.
+        system_content = _SYSTEM
+        if context_text:
+            system_content += f"CONTEXT:\n{context_text}\n"
 
-        # The | operator chains the prompt and the LLM together into a pipeline.
-        # prompt.invoke(...) formats the template, then passes the result to llm.invoke(...).
-        chain = prompt | self.llm
-        response = chain.invoke(
-            {"system": _SYSTEM, "context_section": context_section, "question": question}
-        )
+        messages = [SystemMessage(content=system_content)]
+
+        # Inject the last 6 messages (= 3 user + 3 assistant exchanges) so the
+        # LLM understands follow-up questions like "tell me more about that".
+        if history:
+            for msg in history[-6:]:
+                if msg.get("role") == "user":
+                    messages.append(HumanMessage(content=msg["content"]))
+                elif msg.get("role") == "assistant":
+                    messages.append(AIMessage(content=msg["content"]))
+
+        messages.append(HumanMessage(content=question))
+
+        response = self.llm.invoke(messages)
         return response.content, sources

--- a/rag-service/requirements.txt
+++ b/rag-service/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn[standard]
-langchain-google-genai
+langchain-ollama
 langchain-chroma
 langchain-community
 langchain-text-splitters


### PR DESCRIPTION
## RAG-Based Chatbot Integration                                                                                                                     
                                                            
  Adds a fully local RAG chatbot to StudyHub as part of the 4-SEI-10-899 final assessment.                                                             
   
  ## What's included                                                                                                                                   
                                                            
  - RAG service — standalone Python/FastAPI microservice using LangChain, ChromaDB, and Ollama (gemma4:e4b + nomic-embed-text-v2-moe). Runs        
  entirely on-device, no external API calls at chat time.
  - Knowledge base — studyhub_docs.md covering all features, all 29 API endpoints, authentication, architecture, and user roles                  
  - Off-topic rejection — cosine similarity threshold (0.30) hard-rejects irrelevant questions before the LLM is called
  - Multi-turn context — last 6 messages sent as history; retrieval query enriched with previous user turn so follow-up questions work correctly   
  - Source attribution — every answer returns the source document, rendered as badges in the chat UI                                               
  - Build/runtime separation — index built once on first container start via build_index.py, loaded from disk on every subsequent start          
  - Fallback — if the RAG service or Ollama is unavailable, Go backend falls back to direct Gemini call so the chat widget never breaks            
                                                                                                                                                       
  ## How to test                                                                                                                                       
                                                                                                                                                       
  1. Pull Ollama models: ollama pull gemma4:e4b && ollama pull nomic-embed-text-v2-moe                                                               
  2. docker compose up --build
  3. Open the chat widget in the app and ask anything about StudyHub                                                                                   
                                                                                                                                                       
  ## Checklist
  - [x] RAG service builds and runs in Docker                                                                                                          
  - [x] Off-topic questions rejected consistently           
  - [x] Multi-turn follow-up questions work
  - [x] Source attribution shown in UI                                                                                                                 
  - [x] README updated with chatbot setup instructions
  - [x] Technical documentation updated (`RAG_CHATBOT_DOCS.md`)